### PR TITLE
feat: added migration generate and revert options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,33 @@
 ## Description
-Nest JS jwt authentication service using nest js, docker and mysql. Can be used jwt auth microservice or can be used as starter repo for an api project.  
 
-## Running the app
+NestJS JWT authentication service using NestJS, Docker and MySQL. It can be used as a JWT Auth Microservice or can be used as starter repository for an API project.
 
-## Test
-<!--  -->
+## Running The App
+
+`yarn run start` or `npm run start`
+
+## Migration Commands
+
+Synchronise and initial migration is set to false, so you need to run commands for the migrations. Here are some list of commands:
+
+- Generate migration file with populated up and down functions, from User entity:
+  `yarn migration:generate -n createUsers`
+- Create a template for User table with empty up and down functions:
+  `yarn migration:create -n createUsers`
+- Run migration command:
+  `yarn migration:run`
+- Run migration rollback:
+  `yarn migration:revert`
+
+## Running Test
+
+`yarn test` or `npm run test`
+
+## Contribution Guidelines
+
+Feel free to submit issues or PRs. You can checkout the coding style guide before submitting the PRs. Link is [here](https://github.com/basarat/typescript-book/blob/master/docs/styleguide/styleguide.md).
+
+## Stay in touch
+
+- Author - S M Asad Rahman
+- Twitter - [@asad_rahman](https://twitter.com/asad_rahman)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "migration:create": "ts-node node_modules/.bin/typeorm migration:create  --config src/orm.config.ts",
+    "migration:generate": "ts-node node_modules/.bin/typeorm migration:generate  --config src/orm.config.ts",
+    "migration:run": "ts-node node_modules/.bin/typeorm migration:run  --config src/orm.config.ts",
+    "migration:revert": "ts-node node_modules/.bin/typeorm migration:revert --config src/orm.config.ts"
   },
   "dependencies": {
     "@compodoc/compodoc": "^1.1.10",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,7 @@ import * as ormConfig from './orm.config';
       secret: process.env.JWT_SECRET,
       signOptions: { expiresIn: '60s' },
     }),
+    WinstonModule.forRoot(loggerConf),
     AuthModule,
     UserModule,
     SharedModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,21 +15,11 @@ import { JwtTokenMiddleware, LoggerInterceptor } from './utils';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import * as ormConfig from './orm.config';
 
 @Module({
   imports: [
-    WinstonModule.forRoot(loggerConf),
-    TypeOrmModule.forRoot({
-      type: 'mysql',
-      host: process.env.DB_HOST,
-      port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : null,
-      username: process.env.DB_USER,
-      password: process.env.DB_PASS,
-      database: process.env.DB_NAME,
-      entities: [__dirname + '/**/**/*.entity{.ts,.js}'],
-      synchronize: true,
-      debug: false,
-    }),
+    TypeOrmModule.forRoot(ormConfig),
     JwtModule.register({
       secret: process.env.JWT_SECRET,
       signOptions: { expiresIn: '60s' },

--- a/src/migrations/1567653805565-createUsers.ts
+++ b/src/migrations/1567653805565-createUsers.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class createUsers1567653805565 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("CREATE TABLE `user` (`id` int NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, `email` varchar(320) NOT NULL, `password` varchar(100) NOT NULL, `is_active` tinyint NOT NULL, `roles` text NOT NULL, `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), UNIQUE INDEX `email` (`email`), PRIMARY KEY (`id`)) ENGINE=InnoDB");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("DROP INDEX `email` ON `user`");
+        await queryRunner.query("DROP TABLE `user`");
+    }
+
+}

--- a/src/orm.config.ts
+++ b/src/orm.config.ts
@@ -1,0 +1,22 @@
+import { ConnectionOptions } from 'typeorm';
+
+const config: ConnectionOptions = {
+  type: 'mysql',
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : null,
+  username: process.env.DB_USER,
+  password: process.env.DB_PASS,
+  database: process.env.DB_NAME,
+  entities: [__dirname + '/**/**/*.entity{.ts,.js}'],
+  migrations: [__dirname + '/migrations/**/*{.ts,.js}'],
+  migrationsTableName: 'migrations',
+  migrationsRun: false,
+  cli: {
+    entitiesDir: 'src',
+    migrationsDir: 'src/migrations',
+  },
+  synchronize: false,
+  debug: true,
+};
+
+export = config;


### PR DESCRIPTION
Issue: https://github.com/asad-mlbd/nestjs-jwt-auth/issues/6

**Features**
   - generate migration file with populated up and down functions, from User entity.
  `yarn migration:generate -n createUsers`
   - create a template for User table with empty up and down functions
  `yarn migration:create -n createUsers`
   - run migration command
   `yarn migration:run`
   - run migration rollback
   `yarn migration:revert`

**Breaking changes**
     synchronise and initial migration is set to false, so you need to run commands for the migrations.